### PR TITLE
Add patch for Lightning v0.28.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -22,17 +22,20 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
     version("0.28.1", sha256="038bc11ec913c3b90dd056bd0b134920db0ec5ff6f6a0bb94db6eaa687ce6618")
     version("0.28.0", sha256="f5849c2affb5fb57aca20feb40ca829d171b07db2304fde0a37c2332c5b09e18")
 
-    variant("python", default=True, description="Build with Python support")
-    variant("native", default=False, description="Build natively for given hardware")
-    variant("blas", default=False, description="Build with BLAS support")
-    variant("openmp", default=False, description="Build with OpenMP support")
-    variant("kokkos", default=False, description="Build with Kokkos support")
-    variant("verbose", default=False, description="Build with full verbosity")
+    patch("v0.28-spack_support.patch", when='@0.28.0:0.28.2', sha256="430078f3da285a10bd2d3a14bbdc41c7e8825be12ba713b6ca5dfca3fcc23d88")
+
+    variant("blas", default=True, description="Build with BLAS support")
     variant(
         "dispatcher",
-        default=False,
+        default=True,
         description="Build with AVX2/AVX512 gate automatic dispatching support",
     )
+    variant("kokkos", default=True, description="Build with Kokkos support")
+    variant("openmp", default=True, description="Build with OpenMP support")
+    variant("python", default=True, description="Build with Python support")
+
+    variant("native", default=False, description="Build natively for given hardware")
+    variant("verbose", default=False, description="Build with full verbosity")
 
     variant("cpptests", default=False, description="Build CPP tests")
     variant("cppbenchmarks", default=False, description="Build CPP benchmark examples")

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/v0.28-spack_support.patch
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/v0.28-spack_support.patch
@@ -1,0 +1,1076 @@
+diff --git a/.github/CHANGELOG.md b/.github/CHANGELOG.md
+index 3bad422..b59f5b6 100644
+--- a/.github/CHANGELOG.md
++++ b/.github/CHANGELOG.md
+@@ -1,9 +1,23 @@
++# Release 0.28.2-patch
++
++### Improvements
++
++* Remove runtime dependency on ninja build system.
++[(#414)](https://github.com/PennyLaneAI/pennylane-lightning/pull/414)
++
++* Allow better integration and installation support with CMake targeted binary builds.
++[(#403)](https://github.com/PennyLaneAI/pennylane-lightning/pull/403)
++
++Lee James O'Riordan
++
++---
++
+ # Release 0.28.2
+ 
+ ### Bug fixes
+ 
+ * Fix Python module versioning for Linux wheels.
+-[(#407)](https://github.com/PennyLaneAI/pennylane-lightning/pull/407)
++[(#408)](https://github.com/PennyLaneAI/pennylane-lightning/pull/408)
+ 
+ ### Contributors
+ 
+diff --git a/.github/workflows/benchmarks.yml b/.github/workflows/benchmarks.yml
+index 5340e9a..fd053e9 100644
+--- a/.github/workflows/benchmarks.yml
++++ b/.github/workflows/benchmarks.yml
+@@ -42,4 +42,4 @@ jobs:
+       - name: Run GBenchmark
+         run: |
+             ./BuildGBench/benchmarks/utils --benchmark_filter="^[a-z]+_innerProd_cmplx<double>/[0-9]+$"
+-            ./BuildGBench/benchmarks/apply_operations --benchmark_filter="^applyOperations_RandOps<double>/LM_all/32/[0-9]+$"
++            ./BuildGBench/benchmarks/pennylane_lightning_bench_operations --benchmark_filter="^applyOperations_RandOps<double>/LM_all/32/[0-9]+$"
+diff --git a/.github/workflows/dev_version_script.py b/.github/workflows/dev_version_script.py
+index 82d47e6..f7ab794 100644
+--- a/.github/workflows/dev_version_script.py
++++ b/.github/workflows/dev_version_script.py
+@@ -17,61 +17,68 @@ import importlib
+ 
+ import re
+ 
+-VERSION_FILE_PATH = 'pennylane_lightning/_version.py'
++VERSION_FILE_PATH = "pennylane_lightning/_version.py"
+ 
+-rgx_ver = re.compile('^__version__ = \"(.*?)\"$')
++rgx_ver = re.compile('^__version__ = "(.*?)"$')
++
++rgx_dev_ver = re.compile("^(\d*\.\d*\.\d*)-dev(\d*)$")
+ 
+-rgx_dev_ver = re.compile('^(\d*\.\d*\.\d*)-dev(\d*)$')
+ 
+ def extract_version(package_path):
+-    with package_path.joinpath(VERSION_FILE_PATH).open('r') as f:
++    with package_path.joinpath(VERSION_FILE_PATH).open("r") as f:
+         for line in f.readlines():
+-            if line.startswith('__version__'):
++            if line.startswith("__version__"):
+                 line = line.strip()
+                 m = rgx_ver.match(line)
+                 return m.group(1)
+     raise ValueError("Cannot parse version")
+ 
++
+ def is_dev(version_str):
+     m = rgx_dev_ver.fullmatch(version_str)
+     return m is not None
+ 
++
+ def update_dev_version(package_path, version_str):
+     m = rgx_dev_ver.fullmatch(version_str)
+-    if m.group(2) == '':
++    if m.group(2) == "":
+         curr_dev_ver = 0
+     else:
+         curr_dev_ver = int(m.group(2))
+ 
+-    new_version_str = '{}-dev{}'.format(m.group(1), str(curr_dev_ver + 1))
++    new_version_str = "{}-dev{}".format(m.group(1), str(curr_dev_ver + 1))
+ 
+     lines = []
+-    with package_path.joinpath(VERSION_FILE_PATH).open('r') as f:
++    with package_path.joinpath(VERSION_FILE_PATH).open("r") as f:
+         for line in f.readlines():
+-            if not line.startswith('__version__'):
++            if not line.startswith("__version__"):
+                 lines.append(line)
+             else:
+-                lines.append(f'__version__ = \"{new_version_str}\"\n')
++                lines.append(f'__version__ = "{new_version_str}"\n')
+ 
+-    with package_path.joinpath(VERSION_FILE_PATH).open('w') as f:
+-        f.write(''.join(lines))
++    with package_path.joinpath(VERSION_FILE_PATH).open("w") as f:
++        f.write("".join(lines))
+ 
+ 
+ if __name__ == "__main__":
+     parser = argparse.ArgumentParser()
+-    parser.add_argument("--pr-path", dest = "pr", type=str, required=True, help="Path to the PR dir")
+-    parser.add_argument("--master-path", dest = "master", type=str, required=True, help="Path to the master dir")
++    parser.add_argument("--pr-path", dest="pr", type=str, required=True, help="Path to the PR dir")
++    parser.add_argument(
++        "--master-path", dest="master", type=str, required=True, help="Path to the master dir"
++    )
+ 
+     args = parser.parse_args()
+ 
+     pr_version = extract_version(Path(args.pr))
+     master_version = extract_version(Path(args.master))
+-    
++
+     if pr_version == master_version:
+         if is_dev(pr_version):
+             print("Automatically update version string.")
+             update_dev_version(Path(args.pr), pr_version)
+         else:
+-            print("Even though version of this PR is different from the master, as the PR is not dev, we do nothing.")
++            print(
++                "Even though version of this PR is different from the master, as the PR is not dev, we do nothing."
++            )
+     else:
+         print("Version of this PR is already different from master. Do nothing.")
+diff --git a/.github/workflows/tests_linux.yml b/.github/workflows/tests_linux.yml
+index d2a48c0..fef1187 100644
+--- a/.github/workflows/tests_linux.yml
++++ b/.github/workflows/tests_linux.yml
+@@ -46,7 +46,7 @@ jobs:
+             cmake --build ./Build
+             cd ./Build
+             mkdir -p ./tests/results
+-            ./runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
++            ./pennylane_lightning_test_runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
+ 
+       - name: Upload test results
+         uses: actions/upload-artifact@v3
+@@ -60,7 +60,7 @@ jobs:
+             cmake . -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_KOKKOS=OFF -DENABLE_PYTHON=OFF -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+             cmake --build ./BuildCov
+             cd ./BuildCov
+-            ./runner
++            ./pennylane_lightning_test_runner
+             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
+             lcov --remove coverage.info '/usr/*' --output-file coverage.info
+             mv coverage.info coverage-${{ github.job }}.info
+@@ -159,7 +159,7 @@ jobs:
+             cmake --build ./Build
+             cd ./Build
+             mkdir -p ./tests/results
+-            ./runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
++            ./pennylane_lightning_test_runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
+ 
+       - name: Upload test results
+         uses: actions/upload-artifact@v3
+@@ -173,7 +173,7 @@ jobs:
+             cmake . -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_KOKKOS=OFF -DENABLE_PYTHON=OFF -DENABLE_BLAS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+             cmake --build ./BuildCov
+             cd ./BuildCov
+-            ./runner
++            ./pennylane_lightning_test_runner
+             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
+             lcov --remove coverage.info '/usr/*' --output-file coverage.info
+             mv coverage.info coverage-${{ github.job }}.info
+@@ -298,7 +298,7 @@ jobs:
+             cmake --build ./Build
+             cd ./Build
+             mkdir -p ./tests/results
+-            ./runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
++            ./pennylane_lightning_test_runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
+ 
+       - name: Upload test results
+         uses: actions/upload-artifact@v3
+@@ -312,7 +312,7 @@ jobs:
+             cmake . -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_KOKKOS=ON -DENABLE_PYTHON=OFF -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+             cmake --build ./BuildCov
+             cd ./BuildCov
+-            ./runner
++            ./pennylane_lightning_test_runner
+             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
+             lcov --remove coverage.info '/usr/*' --output-file coverage.info
+             mv coverage.info coverage-${{ github.job }}.info
+@@ -447,7 +447,7 @@ jobs:
+             cmake --build ./Build
+             cd ./Build
+             mkdir -p ./tests/results
+-            ./runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
++            ./pennylane_lightning_test_runner --order lex --reporter junit --out ./tests/results/report_${{ github.job }}.xml
+ 
+       - name: Upload test results
+         uses: actions/upload-artifact@v3
+@@ -461,7 +461,7 @@ jobs:
+             cmake . -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_BLAS=ON -DENABLE_KOKKOS=ON -DENABLE_PYTHON=OFF -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+             cmake --build ./BuildCov
+             cd ./BuildCov
+-            ./runner
++            ./pennylane_lightning_test_runner
+             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
+             lcov --remove coverage.info '/usr/*' --output-file coverage.info
+             mv coverage.info coverage-${{ github.job }}.info
+diff --git a/.github/workflows/tests_windows.yml b/.github/workflows/tests_windows.yml
+index da30e58..438d355 100644
+--- a/.github/workflows/tests_windows.yml
++++ b/.github/workflows/tests_windows.yml
+@@ -36,8 +36,8 @@ jobs:
+             cmake ./pennylane_lightning/src -BBuild  -DBUILD_TESTS=ON -DENABLE_OPENMP=OFF -DENABLE_WARNINGS=OFF
+             cmake --build ./Build --config Debug
+             mkdir -p ./Build/tests/results
+-            .\Build\tests\Debug\runner.exe --order lex --reporter junit --out .\Build\tests\results\report_cpptests.xml
+-            OpenCppCoverage --sources pennylane_lightning\src --export_type cobertura:coverage.xml Build\tests\Debug\runner.exe
++            .\Build\tests\Debug\pennylane_lightning_test_runner.exe --order lex --reporter junit --out .\Build\tests\results\report_cpptests.xml
++            OpenCppCoverage --sources pennylane_lightning\src --export_type cobertura:coverage.xml Build\tests\Debug\pennylane_lightning_test_runner.exe
+             Move-Item -Path .\coverage.xml -Destination .\coverage-${{ github.job }}.xml
+ 
+       - name: Upload test results
+@@ -208,8 +208,8 @@ jobs:
+             cmake ./pennylane_lightning/src -BBuild  -DBUILD_TESTS=ON -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=D:\a\pennylane-lightning\pennylane-lightning\Kokkos -DENABLE_OPENMP=OFF -DENABLE_WARNINGS=OFF -T clangcl
+             cmake --build ./Build --config Debug -- /p:UseMultiToolTask=true /p:EnforceProcessCountAcrossBuilds=true /p:MultiProcMaxCount=2
+             mkdir -p ./Build/tests/results
+-            .\Build\tests\Debug\runner.exe --order lex --reporter junit --out .\Build\tests\results\report_${{ github.job }}.xml
+-            OpenCppCoverage --sources pennylane_lightning\src --export_type cobertura:coverage.xml Build\tests\Debug\runner.exe
++            .\Build\tests\Debug\pennylane_lightning_test_runner.exe --order lex --reporter junit --out .\Build\tests\results\report_${{ github.job }}.xml
++            OpenCppCoverage --sources pennylane_lightning\src --export_type cobertura:coverage.xml Build\tests\Debug\pennylane_lightning_test_runner.exe
+             Move-Item -Path .\coverage.xml -Destination .\coverage-${{ github.job }}.xml
+ 
+       - name: Upload test results
+diff --git a/.github/workflows/vb_script.py b/.github/workflows/vb_script.py
+index 722cb31..2595bfd 100644
+--- a/.github/workflows/vb_script.py
++++ b/.github/workflows/vb_script.py
+@@ -13,20 +13,21 @@
+ # limitations under the License.
+ import argparse
+ import pennylane as qml
++
+ pl_version = '"' + qml.version() + '"'
+ 
+ 
+ def remove_quotes(my_str):
+-    """ A helper function to remove the quote chars (',")
++    """A helper function to remove the quote chars (',")
+     from the provided str.
+     """
+-    clean_str = my_str.replace('"', '')  # remove "
++    clean_str = my_str.replace('"', "")  # remove "
+     clean_str = clean_str.replace("'", "")  # remove '
+     return clean_str
+ 
+ 
+ def bump_version(version_line, pre_release):
+-    """ A helper function which takes the current version string and
++    """A helper function which takes the current version string and
+     replaces it with the bumped version depending on the pre/post
+     release flag.
+ 
+@@ -42,16 +43,20 @@ def bump_version(version_line, pre_release):
+         bumped_version (string): The bumped version string.
+     """
+     data = version_line.split(" ")
+-    curr_version = data[-1].replace('\n', '')  # remove any newline characters
++    curr_version = data[-1].replace("\n", "")  # remove any newline characters
+ 
+     if pre_release:
+         curr_version = pl_version  # get current Pennylane version
+ 
+     split_version = curr_version.split(".")  # "0.17.0" --> ["0,17,0"]
+-    split_version[1] = str(int(split_version[1]) + 1)  # take middle value and cast as int and bump it by 1
++    split_version[1] = str(
++        int(split_version[1]) + 1
++    )  # take middle value and cast as int and bump it by 1
+ 
+     if not pre_release:
+-        split_version[2] = split_version[2].replace('"', '-dev"')  # add -dev, ["0,18,0"] --> ["0,18,0-dev"]
++        split_version[2] = split_version[2].replace(
++            '"', '-dev"'
++        )  # add -dev, ["0,18,0"] --> ["0,18,0-dev"]
+ 
+     bumped_version = ".".join(split_version)
+     data[-1] = bumped_version
+@@ -61,7 +66,7 @@ def bump_version(version_line, pre_release):
+ 
+ 
+ def update_version_file(path, pre_release=True):
+-    """ Updates the __version__ attribute in a specific version file.
++    """Updates the __version__ attribute in a specific version file.
+ 
+     Args:
+         path (str): The path to the version file.
+@@ -71,21 +76,21 @@ def update_version_file(path, pre_release=True):
+     Return:
+         new_version (str): The bumped version string.
+     """
+-    with open(path, 'r', encoding="utf8") as f:
++    with open(path, "r", encoding="utf8") as f:
+         lines = f.readlines()
+ 
+-    with open(path, 'w', encoding="utf8") as f:
++    with open(path, "w", encoding="utf8") as f:
+         for line in lines:
+-            if "__version__" in line.split(' '):
++            if "__version__" in line.split(" "):
+                 new_line, new_version = bump_version(line, pre_release)
+-                f.write(new_line + '\n')
++                f.write(new_line + "\n")
+             else:
+                 f.write(line)
+     return new_version
+ 
+ 
+ def remove_empty_headers(lines):
+-    """ Takes a paragraph (list of strings) and removes sections which are empty.
++    """Takes a paragraph (list of strings) and removes sections which are empty.
+     Where a section begins with a header (### Header_Title).
+ 
+     Args:
+@@ -109,20 +114,20 @@ def remove_empty_headers(lines):
+                 pntr1 = pntr2
+                 is_empty = True  # reset the empty flag
+ 
+-            elif line2 == '\n':
++            elif line2 == "\n":
+                 pass
+ 
+             else:
+                 is_empty = False
+ 
+-        cleaned_lines.extend(lines[pntr1:pntr1+1])
++        cleaned_lines.extend(lines[pntr1 : pntr1 + 1])
+         pntr1 += 1
+ 
+     return cleaned_lines
+ 
+ 
+ def update_changelog(path, new_version, pre_release=True):
+-    """ Updates the Changelog file depending on whether it's a pre-release
++    """Updates the Changelog file depending on whether it's a pre-release
+     or post-release version bump.
+ 
+     Args:
+@@ -131,7 +136,7 @@ def update_changelog(path, new_version, pre_release=True):
+         pre_release (bool): A flag which determines if this is a
+             pre-release or post-release version bump.
+     """
+-    with open(path, 'r', encoding="utf8") as f:
++    with open(path, "r", encoding="utf8") as f:
+         lines = f.readlines()
+         end_of_section_index = 0
+         for index, line in enumerate(lines):
+@@ -139,11 +144,13 @@ def update_changelog(path, new_version, pre_release=True):
+                 end_of_section_index = index
+                 break
+ 
+-    with open(path, 'w', encoding="utf8") as f:
++    with open(path, "w", encoding="utf8") as f:
+         if not pre_release:  # post_release append template to top of the changelog
+-            with open("./.github/workflows/changelog_template.txt", 'r', encoding="utf8") as template_f:
++            with open(
++                "./.github/workflows/changelog_template.txt", "r", encoding="utf8"
++            ) as template_f:
+                 template_lines = template_f.readlines()
+-                template_lines[0] = template_lines[0].replace('x.x.x-dev', new_version)
++                template_lines[0] = template_lines[0].replace("x.x.x-dev", new_version)
+                 f.writelines(template_lines)
+                 f.writelines(lines)
+ 
+@@ -152,7 +159,7 @@ def update_changelog(path, new_version, pre_release=True):
+             line = lines[0]
+             split_line = line.split(" ")
+             split_line[-1] = new_version  # replace version (split_line = [#, Release, 0.17.0-dev])
+-            new_line = " ".join(split_line) + '\n'
++            new_line = " ".join(split_line) + "\n"
+             f.write(new_line)
+ 
+             # remover empty headers
+@@ -166,12 +173,22 @@ def update_changelog(path, new_version, pre_release=True):
+ 
+ if __name__ == "__main__":
+     parser = argparse.ArgumentParser()
+-    parser.add_argument("--version_path", type=str, required=True, help="Path to the _version.py file")
++    parser.add_argument(
++        "--version_path", type=str, required=True, help="Path to the _version.py file"
++    )
+     parser.add_argument("--changelog_path", type=str, required=True, help="Path to the changelog")
+-    parser.add_argument("--pre_release", dest="release_status", action="store_true",
+-                        help="True if this is a pre-release version bump, False if it is post release")
+-    parser.add_argument("--post_release", dest="release_status", action="store_false",
+-                        help="True if this is a pre-release version bump, False if it is post release")
++    parser.add_argument(
++        "--pre_release",
++        dest="release_status",
++        action="store_true",
++        help="True if this is a pre-release version bump, False if it is post release",
++    )
++    parser.add_argument(
++        "--post_release",
++        dest="release_status",
++        action="store_false",
++        help="True if this is a pre-release version bump, False if it is post release",
++    )
+ 
+     args = parser.parse_args()
+     updated_version = update_version_file(args.version_path, args.release_status)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dbc3d77..21aa319 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,7 @@ target_link_libraries(pennylane_lightning INTERFACE     lightning_utils
+                                                         lightning_algorithms
+                                                         lightning_gates
+ )
+-target_include_directories(pennylane_lightning INTERFACE "pennylane_lightning/src")
++target_include_directories(pennylane_lightning  INTERFACE "$<INSTALL_INTERFACE:${PROJECT_SOURCE_DIR}/pennylane_lightning/src;include>")
+ 
+ #####################################################
+ if(ENABLE_PYTHON)
+@@ -108,6 +108,12 @@ install(TARGETS pennylane_lightning
+         LIBRARY DESTINATION lib
+         ARCHIVE DESTINATION lib
+         INCLUDES DESTINATION include
++        PUBLIC_HEADER DESTINATION include
++)
++
++install(DIRECTORY 
++    ${PROJECT_SOURCE_DIR}/pennylane_lightning/src
++    DESTINATION include/pennylane_lightning
+ )
+ 
+ if (BUILD_TESTS)
+diff --git a/Makefile b/Makefile
+index 305b59e..9d3a2a3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -79,32 +79,32 @@ coverage-cpp:
+ 	rm -rf ./BuildCov
+ 	cmake pennylane_lightning/src -BBuildCov  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON
+ 	cmake --build ./BuildCov
+-	cd ./BuildCov; ./tests/runner; \
++	cd ./BuildCov; ./tests/pennylane_lightning_test_runner; \
+ 	lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info; \
+ 	genhtml coverage.info --output-directory out
+ 
+ test-cpp:
+ 	rm -rf ./BuildTests
+ 	cmake $(LIGHTNING_CPP_DIR) -BBuildTests -DBUILD_TESTS=ON
+-	cmake --build ./BuildTests --target runner
++	cmake --build ./BuildTests --target pennylane_lightning_test_runner
+ 	cmake --build ./BuildTests --target test
+ 
+ test-cpp-blas:
+ 	rm -rf ./BuildTests
+ 	cmake $(LIGHTNING_CPP_DIR) -BBuildTests -DBUILD_TESTS=ON -DENABLE_BLAS=ON
+-	cmake --build ./BuildTests --target runner
++	cmake --build ./BuildTests --target pennylane_lightning_test_runner
+ 	cmake --build ./BuildTests --target test
+ 
+ test-cpp-no-omp:
+ 	rm -rf ./BuildTests
+ 	cmake $(LIGHTNING_CPP_DIR) -BBuildTests -DBUILD_TESTS=ON -DENABLE_OPENMP=OFF
+-	cmake --build ./BuildTests --target runner
++	cmake --build ./BuildTests --target pennylane_lightning_test_runner
+ 	cmake --build ./BuildTests --target test
+ 
+ test-cpp-kokkos:
+ 	rm -rf ./BuildTests
+ 	cmake $(LIGHTNING_CPP_DIR) -BBuildTests -DBUILD_TESTS=ON -DENABLE_KOKKOS=ON
+-	cmake --build ./BuildTests --target runner
++	cmake --build ./BuildTests --target pennylane_lightning_test_runner
+ 	cmake --build ./BuildTests --target test
+ 
+ .PHONY: gbenchmark
+diff --git a/bin/utils.py b/bin/utils.py
+index 6834078..f33bf6a 100644
+--- a/bin/utils.py
++++ b/bin/utils.py
+@@ -9,17 +9,18 @@ LIGHTNING_SOURCE_DIR = Path(__file__).resolve().parent.parent
+ 
+ rgx_gitignore_comment = re_compile("#.*$")
+ 
+-def get_cpp_files_from_path(path, ignore_patterns = None, use_gitignore = True, header_only = False):
++
++def get_cpp_files_from_path(path, ignore_patterns=None, use_gitignore=True, header_only=False):
+     """return set of C++ source files from a path
+ 
+     Args:
+-        paths (pathlib.Path or str): a path to process 
++        paths (pathlib.Path or str): a path to process
+         ignore_patterns: patterns to ignore
+         use_gitignore: find ignore patterns from .gitignore
+         header_only: find only header files when true
+     """
+     path = Path(path)
+-    files_rel = set() # file paths relative to path
++    files_rel = set()  # file paths relative to path
+ 
+     exts = HEADERFILE_EXT
+     if not header_only:
+@@ -33,15 +34,15 @@ def get_cpp_files_from_path(path, ignore_patterns = None, use_gitignore = True,
+ 
+     if use_gitignore:
+         # simple gitignore parser
+-        gitignore_file = path.joinpath('.gitignore')
++        gitignore_file = path.joinpath(".gitignore")
+         if gitignore_file.exists():
+             with gitignore_file.open() as f:
+                 for line in f.readlines():
+-                    line = rgx_gitignore_comment.sub('', line)
++                    line = rgx_gitignore_comment.sub("", line)
+                     line = line.strip()
+                     if line:
+                         ignore_patterns.append(line)
+-    
++
+     files_to_remove = set()
+     for ignore_pattern in ignore_patterns:
+         for f in files_rel:
+@@ -51,8 +52,9 @@ def get_cpp_files_from_path(path, ignore_patterns = None, use_gitignore = True,
+     files_rel -= files_to_remove
+ 
+     return set(str(path.joinpath(f)) for f in files_rel)
+-    
+-def get_cpp_files(paths, ignore_patterns = None, use_gitignore = True, header_only = False):
++
++
++def get_cpp_files(paths, ignore_patterns=None, use_gitignore=True, header_only=False):
+     """return list of C++ source files from paths.
+ 
+     Args:
+diff --git a/doc/conf.py b/doc/conf.py
+index 7a78043..6ce30e2 100644
+--- a/doc/conf.py
++++ b/doc/conf.py
+@@ -105,7 +105,9 @@ automodsumm_inherited_members = True
+ breathe_projects = {"Lightning-Qubit": "./doxyoutput/xml"}
+ breathe_default_project = "Lightning-Qubit"
+ 
+-mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
++mathjax_path = (
++    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
++)
+ 
+ # Exhale extension
+ # Setup the exhale extension
+@@ -130,6 +132,7 @@ exhale_args = {
+ 
+ # Add any paths that contain templates here, relative to this directory.
+ from pennylane_sphinx_theme import templates_dir
++
+ templates_path = [templates_dir()]
+ 
+ # The suffix(es) of source filenames.
+@@ -197,7 +200,7 @@ html_favicon = "_static/favicon.ico"
+ html_static_path = ["_static"]
+ 
+ html_css_files = [
+-    'css/custom.css',
++    "css/custom.css",
+ ]
+ 
+ # -- html theme ---------------------------------------------------------
+@@ -209,10 +212,9 @@ html_theme_options = {
+     "navbar_active_link": 3,
+     "google_analytics_tracking_id": "UA-130507810-1",
+     "extra_copyrights": [
+-        "TensorFlow, the TensorFlow logo, and any related marks are trademarks "
+-        "of Google Inc."
++        "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
+     ],
+-    "toc_overview": True
++    "toc_overview": True,
+ }
+ 
+ edit_on_github_project = "PennyLaneAI/pennylane-lightning"
+diff --git a/pennylane_lightning/_serialize.py b/pennylane_lightning/_serialize.py
+index 1e2359c..0338b7c 100644
+--- a/pennylane_lightning/_serialize.py
++++ b/pennylane_lightning/_serialize.py
+@@ -174,7 +174,6 @@ def _serialize_ops(
+             op_list = [o]
+ 
+         for single_op in op_list:
+-
+             name = single_op.name
+             names.append(name)
+ 
+diff --git a/pennylane_lightning/_version.py b/pennylane_lightning/_version.py
+index 9ed9c42..b2543ed 100644
+--- a/pennylane_lightning/_version.py
++++ b/pennylane_lightning/_version.py
+@@ -16,4 +16,4 @@
+    Version number (major.minor.patch[-label])
+ """
+ 
+-__version__ = "0.28.2"
++__version__ = "0.28.3"
+diff --git a/pennylane_lightning/src/algorithms/CMakeLists.txt b/pennylane_lightning/src/algorithms/CMakeLists.txt
+index 50e315a..3bfcbe4 100644
+--- a/pennylane_lightning/src/algorithms/CMakeLists.txt
++++ b/pennylane_lightning/src/algorithms/CMakeLists.txt
+@@ -3,7 +3,7 @@ project(lightning_algorithms LANGUAGES CXX)
+ set(ALGORITHM_FILES AdjointDiff.cpp JacobianTape.cpp StateVecAdjDiff.cpp CACHE INTERNAL "" FORCE)
+ add_library(lightning_algorithms STATIC ${ALGORITHM_FILES})
+ 
+-target_link_libraries(lightning_algorithms PRIVATE lightning_compile_options
++target_link_libraries(lightning_algorithms PUBLIC lightning_compile_options
+                                                    lightning_external_libs
+                                                    lightning_gates
+                                                    lightning_simulator
+diff --git a/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp b/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp
+index e77559c..3cde10d 100644
+--- a/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp
++++ b/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp
+@@ -42,12 +42,12 @@ static void create_random_cmplx_vector(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(create_random_cmplx_vector<float>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(create_random_cmplx_vector<double>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ //***********************************************************************//
+ //                            Inner Product
+@@ -82,12 +82,12 @@ template <class T> static void std_innerProd_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(std_innerProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(std_innerProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ /**
+  * @brief Benchmark Util::omp_innerProd for two vectors of complex
+@@ -111,18 +111,20 @@ template <class T> static void omp_innerProd_cmplx(benchmark::State &state) {
+ 
+     for (auto _ : state) {
+         std::complex<T> res(.0, .0);
++        // Create indirection to avoid GCC issue with AVX512 compilation
++        std::complex<T> *res_ptr = &res;
+ 
+-        Util::omp_innerProd(vec1.data(), vec2.data(), res, sz);
+-        benchmark::DoNotOptimize(res);
++        Util::omp_innerProd(vec1.data(), vec2.data(), *res_ptr, sz);
++        benchmark::DoNotOptimize(res_ptr);
+     }
+ }
+ BENCHMARK(omp_innerProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(omp_innerProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ #if __has_include(<cblas.h>) && defined _ENABLE_BLAS
+ /**
+@@ -147,23 +149,25 @@ template <class T> static void blas_innerProd_cmplx(benchmark::State &state) {
+ 
+     for (auto _ : state) {
+         std::complex<T> res(.0, .0);
++        // Create indirection to avoid GCC issue with AVX512 compilation
++        std::complex<T> *res_ptr = &res;
+ 
+         if constexpr (std::is_same_v<T, float>) {
+-            cblas_cdotc_sub(sz, vec1.data(), 1, vec2.data(), 1, &res);
++            cblas_cdotc_sub(sz, vec1.data(), 1, vec2.data(), 1, res_ptr);
+         } else if constexpr (std::is_same_v<T, double>) {
+-            cblas_zdotc_sub(sz, vec1.data(), 1, vec2.data(), 1, &res);
++            cblas_zdotc_sub(sz, vec1.data(), 1, vec2.data(), 1, res_ptr);
+         }
+ 
+-        benchmark::DoNotOptimize(res);
++        benchmark::DoNotOptimize(res_ptr);
+     }
+ }
+ BENCHMARK(blas_innerProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(blas_innerProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ #endif
+ 
+ //***********************************************************************//
+@@ -199,12 +203,12 @@ template <class T> static void naive_transpose_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(naive_transpose_cmplx<float>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(naive_transpose_cmplx<double>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ /**
+  * @brief Benchmark Util::CFTranspose for a randomly generated matrix
+@@ -233,20 +237,20 @@ static void cf_transpose_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(cf_transpose_cmplx<float, 16>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(cf_transpose_cmplx<double, 16>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(cf_transpose_cmplx<float, 32>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ BENCHMARK(cf_transpose_cmplx<double, 32>)
+-    ->RangeMultiplier(1l << 3)
+-    ->Range(1l << 5, 1l << 10);
++    ->RangeMultiplier(1U << 3)
++    ->Range(1U << 5, 1U << 10);
+ 
+ //***********************************************************************//
+ //                         Matrix-Vector Product
+@@ -283,12 +287,12 @@ static void omp_matrixVecProd_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(omp_matrixVecProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ 
+ BENCHMARK(omp_matrixVecProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ 
+ #if __has_include(<cblas.h>) && defined _ENABLE_BLAS
+ /**
+@@ -332,12 +336,12 @@ static void blas_matrixVecProd_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(blas_matrixVecProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ 
+ BENCHMARK(blas_matrixVecProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ #endif
+ 
+ //***********************************************************************//
+@@ -377,12 +381,12 @@ static void omp_matrixMatProd_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(omp_matrixMatProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ 
+ BENCHMARK(omp_matrixMatProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ 
+ #if __has_include(<cblas.h>) && defined _ENABLE_BLAS
+ /**
+@@ -427,12 +431,12 @@ static void blas_matrixMatProd_cmplx(benchmark::State &state) {
+     }
+ }
+ BENCHMARK(blas_matrixMatProd_cmplx<float>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ 
+ BENCHMARK(blas_matrixMatProd_cmplx<double>)
+-    ->RangeMultiplier(1l << 2)
+-    ->Range(1l << 4, 1l << 8);
++    ->RangeMultiplier(1U << 2)
++    ->Range(1U << 4, 1U << 8);
+ #endif
+ 
+ //***********************************************************************//
+@@ -528,7 +532,8 @@ template <class T> static void blas_scaleAndAdd_cmplx(benchmark::State &state) {
+ 
+     std::vector<std::complex<T>> vec1;
+     std::vector<std::complex<T>> vec2;
+-    std::complex<T> scale{std::cos(0.4123), std::sin(0.4123)};
++    std::complex<T> scale{std::cos(static_cast<T>(0.4123)),
++                          std::sin(static_cast<T>(0.4123))};
+ 
+     for (size_t i = 0; i < sz; i++) {
+         vec1.push_back({distr(eng), distr(eng)});
+diff --git a/pennylane_lightning/src/benchmarks/CMakeLists.txt b/pennylane_lightning/src/benchmarks/CMakeLists.txt
+index 3ce0a98..e316f55 100644
+--- a/pennylane_lightning/src/benchmarks/CMakeLists.txt
++++ b/pennylane_lightning/src/benchmarks/CMakeLists.txt
+@@ -66,24 +66,24 @@ target_link_libraries(utils PRIVATE lightning_benchmarks_dependency
+                                     benchmark::benchmark_main)
+ 
+ ################################################################################
+-# Add benchmark_apply_operations exe
++# Add pennylane_lightning_bench_operations exe
+ ################################################################################
+ 
+-add_executable(apply_operations Bench_ApplyOperations.cpp)
++add_executable(pennylane_lightning_bench_operations Bench_ApplyOperations.cpp)
+ 
+-target_link_libraries(apply_operations PRIVATE lightning_benchmarks_dependency
++target_link_libraries(pennylane_lightning_bench_operations PRIVATE lightning_benchmarks_dependency
+                                                benchmark::benchmark_main)
+ 
+ ################################################################################
+-# Add bench_kernels
++# Add pennylane_lightning_bench_kernels
+ ################################################################################
+ 
+-add_executable(bench_kernels Bench_Kernels.cpp)
+-target_link_libraries(bench_kernels PRIVATE lightning_benchmarks_dependency
++add_executable(pennylane_lightning_bench_kernels Bench_Kernels.cpp)
++target_link_libraries(pennylane_lightning_bench_kernels PRIVATE lightning_benchmarks_dependency
+                                             benchmark::benchmark)
+ 
+ 
+-add_custom_command(TARGET bench_kernels POST_BUILD 
++add_custom_command(TARGET pennylane_lightning_bench_kernels POST_BUILD 
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink
+                            ${PROJECT_SOURCE_DIR}/benchmark_all.sh
+                            ${PROJECT_BINARY_DIR}/benchmark_all.sh
+@@ -92,7 +92,7 @@ add_custom_command(TARGET bench_kernels POST_BUILD
+                            ${PROJECT_BINARY_DIR}/plot_gate_benchmark.py
+ )
+ 
+-install(TARGETS bench_kernels apply_operations DESTINATION bin)
++install(TARGETS pennylane_lightning_bench_kernels pennylane_lightning_bench_operations DESTINATION bin)
+ install(FILES 
+     ${PROJECT_SOURCE_DIR}/benchmark_all.sh 
+     ${PROJECT_SOURCE_DIR}/plot_gate_benchmark.py 
+diff --git a/pennylane_lightning/src/benchmarks/README.md b/pennylane_lightning/src/benchmarks/README.md
+index de228ea..ae1d307 100644
+--- a/pennylane_lightning/src/benchmarks/README.md
++++ b/pennylane_lightning/src/benchmarks/README.md
+@@ -95,11 +95,11 @@ Besides, one can use `--benchmark_time_unit` to get the results in `ns`, `us`, `
+ Check **GB CLI Flags** for the list of flags. 
+ 
+ 
+-### `benchmarks/apply_operations`
++### `benchmarks/pennylane_lightning_bench_operations`
+ To benchmark the `Pennylane::StateVectorManagedCPU` and `applyOperation` in PennyLane-Lightning, one can run:
+ ```console
+ $ make gbenchmark
+-$ ./BuildGBench/benchmarks/apply_operations
++$ ./BuildGBench/benchmarks/pennylane_lightning_bench_operations
+ ```
+ 
+ The following arguments could be altered:
+@@ -150,11 +150,11 @@ One can use `--benchmark_format` to get the results in other formats: `<console|
+ Check **GB CLI Flags** for the list of flags. 
+ 
+ 
+-### `benchmarks/bench_kernels`
++### `benchmarks/pennylane_lightning_bench_kernels`
+ To benchmark the `Pennylane::StateVectorManagedCPU` for all gates, generators, matrix operations using different kernels:
+ ```console
+ $ make gbenchmark
+-$ ./BuildGBench/benchmarks/bench_kernels
++$ ./BuildGBench/benchmarks/pennylane_lightning_bench_kernels
+ ```
+ 
+ The output is
+diff --git a/pennylane_lightning/src/tests/CMakeLists.txt b/pennylane_lightning/src/tests/CMakeLists.txt
+index b33b512..a46ebcf 100644
+--- a/pennylane_lightning/src/tests/CMakeLists.txt
++++ b/pennylane_lightning/src/tests/CMakeLists.txt
+@@ -94,14 +94,14 @@ set(TEST_SOURCES CreateAllWires.cpp
+                  Test_StateVectorRawCPU.cpp
+                  Test_Util.cpp)
+ 
+-add_executable(runner ${TEST_SOURCES})
+-target_link_libraries(runner PRIVATE lightning_tests_dependency
++add_executable(pennylane_lightning_test_runner ${TEST_SOURCES})
++target_link_libraries(pennylane_lightning_test_runner PRIVATE lightning_tests_dependency
+                                      lightning_compile_options
+                                      lightning_external_libs)
+-catch_discover_tests(runner)
++catch_discover_tests(pennylane_lightning_test_runner)
+ 
+ # We build compile time tests before the runtime tests as build error messages
+ # are horrible if compile time constants are not well defined.
+-add_dependencies(runner compile_time_tests)
++add_dependencies(pennylane_lightning_test_runner compile_time_tests)
+ 
+-install(TARGETS runner DESTINATION bin)
+\ No newline at end of file
++install(TARGETS pennylane_lightning_test_runner DESTINATION bin)
+\ No newline at end of file
+diff --git a/pennylane_lightning/src/util/LinearAlgebra.hpp b/pennylane_lightning/src/util/LinearAlgebra.hpp
+index 81674ae..e6e825c 100644
+--- a/pennylane_lightning/src/util/LinearAlgebra.hpp
++++ b/pennylane_lightning/src/util/LinearAlgebra.hpp
+@@ -81,16 +81,12 @@ omp_innerProd(const std::complex<T> *v1, const std::complex<T> *v2,
+ #pragma omp declare \
+             reduction (sm:std::complex<T>:omp_out=ConstSum(omp_out, omp_in)) \
+             initializer(omp_priv=std::complex<T> {0, 0})
+-#endif
+ 
+-#if defined(_OPENMP)
+     size_t nthreads = data_size / NTERMS;
+     if (nthreads < 1) {
+         nthreads = 1;
+     }
+-#endif
+ 
+-#if defined(_OPENMP)
+ #pragma omp parallel for num_threads(nthreads) default(none)                   \
+     shared(v1, v2, data_size) reduction(sm                                     \
+                                         : result)
+diff --git a/setup.py b/setup.py
+index 4a795fb..23f3a27 100644
+--- a/setup.py
++++ b/setup.py
+@@ -20,6 +20,7 @@ from pathlib import Path
+ from setuptools import setup, Extension, find_packages
+ from setuptools.command.build_ext import build_ext
+ 
++
+ class CMakeExtension(Extension):
+     def __init__(self, name, sourcedir=""):
+         Extension.__init__(self, name, sources=[])
+@@ -53,8 +54,8 @@ class CMakeBuild(build_ext):
+         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+         configure_args = [
+             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
+-            f"-DPython_EXECUTABLE={sys.executable}", # (Windows)
+-            f"-DPYTHON_EXECUTABLE={sys.executable}", # (Ubuntu)
++            f"-DPython_EXECUTABLE={sys.executable}",  # (Windows)
++            f"-DPYTHON_EXECUTABLE={sys.executable}",  # (Ubuntu)
+             "-DENABLE_WARNINGS=OFF",  # Ignore warnings
+         ]
+ 
+@@ -65,10 +66,11 @@ class CMakeBuild(build_ext):
+                 "-T clangcl",
+             ]
+         else:
+-            configure_args += [
+-                "-GNinja",
+-                f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
+-            ]
++            if ninja_path:
++                configure_args += [
++                    "-GNinja",
++                    f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
++                ]
+ 
+         build_args = []
+ 
+@@ -82,17 +84,19 @@ class CMakeBuild(build_ext):
+ 
+         # Add more platform dependent options
+         if platform.system() == "Darwin":
+-            #To support ARM64
+-            if os.getenv('ARCHS') == "arm64":
+-                configure_args += ["-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11",
+-                                   "-DCMAKE_SYSTEM_NAME=Darwin",
+-                                   "-DCMAKE_SYSTEM_PROCESSOR=ARM64"]
+-            else: # X64 arch
++            # To support ARM64
++            if os.getenv("ARCHS") == "arm64":
++                configure_args += [
++                    "-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11",
++                    "-DCMAKE_SYSTEM_NAME=Darwin",
++                    "-DCMAKE_SYSTEM_PROCESSOR=ARM64",
++                ]
++            else:  # X64 arch
+                 llvmpath = subprocess.check_output(["brew", "--prefix", "llvm"]).decode().strip()
+                 configure_args += [
+-                        f"-DCMAKE_CXX_COMPILER={llvmpath}/bin/clang++",
+-                        f"-DCMAKE_LINKER={llvmpath}/bin/lld",
+-                ] # Use clang instead of appleclang
++                    f"-DCMAKE_CXX_COMPILER={llvmpath}/bin/clang++",
++                    f"-DCMAKE_LINKER={llvmpath}/bin/lld",
++                ]  # Use clang instead of appleclang
+             # Disable OpenMP in M1 Macs
+             if os.environ.get("USE_OMP"):
+                 configure_args += []
+@@ -108,14 +112,15 @@ class CMakeBuild(build_ext):
+             os.makedirs(self.build_temp)
+ 
+         subprocess.check_call(["cmake", str(ext.sourcedir)] + configure_args, cwd=self.build_temp)
+-        subprocess.check_call(["cmake", "--build", ".", "--verbose"] + build_args, cwd=self.build_temp)
++        subprocess.check_call(
++            ["cmake", "--build", ".", "--verbose"] + build_args, cwd=self.build_temp
++        )
++
+ 
+ with open(os.path.join("pennylane_lightning", "_version.py")) as f:
+     version = f.readlines()[-1].split()[-1].strip("\"'")
+ 
+ requirements = [
+-    "ninja",
+-    "numpy",
+     "pennylane>=0.28",
+ ]
+ 
+@@ -127,7 +132,9 @@ info = {
+     "url": "https://github.com/XanaduAI/pennylane-lightning",
+     "license": "Apache License 2.0",
+     "packages": find_packages(where="."),
+-    "package_data": {"pennylane_lightning": [os.path.join("src", "*"), os.path.join("src", "**", "*")]},
++    "package_data": {
++        "pennylane_lightning": [os.path.join("src", "*"), os.path.join("src", "**", "*")]
++    },
+     "include_package_data": True,
+     "entry_points": {
+         "pennylane.plugins": [
+@@ -144,7 +151,7 @@ info = {
+     else [],
+     "cmdclass": {"build_ext": CMakeBuild},
+     "ext_package": "pennylane_lightning",
+-    "extras_require": {"gpu" : ["pennylane-lightning-gpu"]}
++    "extras_require": {"gpu": ["pennylane-lightning-gpu"]},
+ }
+ 
+ classifiers = [
+diff --git a/tests/test_decomposition.py b/tests/test_decomposition.py
+index 9bd19ab..3be39c5 100644
+--- a/tests/test_decomposition.py
++++ b/tests/test_decomposition.py
+@@ -38,7 +38,6 @@ class TestDenseMatrixDecompositionThreshold:
+ 
+     @pytest.mark.parametrize("op, n_wires, condition", input)
+     def test_threshold(self, op, n_wires, condition):
+-
+         wires = np.linspace(0, n_wires - 1, n_wires, dtype=int)
+         op = op(wires=wires)
+         assert LightningQubit.stopping_condition.__get__(op)(op) == condition


### PR DESCRIPTION
This PR creates a patch update for the v0.28.2 lightning release, and ensures the optimal defaults are chosen for the package at build time.

The patch follows the main-release of Lightning to i) remove ninja as a runtime dependency, ii) updates the builders to more coherently work with Spack.